### PR TITLE
Add FastboardTest target and guard FastProxy selector handling

### DIFF
--- a/Example/Fastboard.xcodeproj/project.pbxproj
+++ b/Example/Fastboard.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2ECE8C6F5A81E613E3C86837 /* FastProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FC951F612AA06A8376825E3B /* FastProxyTests.m */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
@@ -48,6 +49,7 @@
 		8AFA91D5278C396D00E0CA61 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		8AFA91E4278D85CB00E0CA61 /* CustomFastboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE965812788350000722F89 /* CustomFastboardView.swift */; };
 		98E446F52ACA5CBDABBD26E9 /* Pods_OCExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6E431A78571212D291FEE81 /* Pods_OCExample.framework */; };
+		9DFFCA4842C8D67D3B523C67 /* FastProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = F54E2A44D0AF5CC27D05DCEC /* FastProxy.m */; };
 		FEFB49723EE700DB0F909007 /* Pods_Fastboard_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30F099742273D1E816E706CE /* Pods_Fastboard_Example.framework */; };
 /* End PBXBuildFile section */
 
@@ -55,6 +57,7 @@
 		22C403ED202C8833654663D1 /* Pods-Fastboard_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Fastboard_Example.release.xcconfig"; path = "Target Support Files/Pods-Fastboard_Example/Pods-Fastboard_Example.release.xcconfig"; sourceTree = "<group>"; };
 		232246E3091BF31CA271C55B /* README-zh.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = "README-zh.md"; path = "../README-zh.md"; sourceTree = "<group>"; };
 		30F099742273D1E816E706CE /* Pods_Fastboard_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Fastboard_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3AEECDDEE22FE3EA5FB0BA80 /* FastboardTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = FastboardTest.xctest; path = FastboardTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		470BB35885E53C67CAAA0CAC /* Pods-Fastboard_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Fastboard_Example.debug.xcconfig"; path = "Target Support Files/Pods-Fastboard_Example/Pods-Fastboard_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		5735BD3E615FCD4E13798F44 /* Fastboard.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Fastboard.podspec; path = ../Fastboard.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		607FACD01AFB9204008FA782 /* Fastboard_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Fastboard_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -66,6 +69,7 @@
 		607FACDF1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		812F452516B81B7ADBC6F7AC /* Pods-Fastboard_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Fastboard_Tests.release.xcconfig"; path = "Target Support Files/Pods-Fastboard_Tests/Pods-Fastboard_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		829F94F2DB88098BADCF84A3 /* Pods-OCExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCExample.debug.xcconfig"; path = "Target Support Files/Pods-OCExample/Pods-OCExample.debug.xcconfig"; sourceTree = "<group>"; };
+		8389C4B657CBD4AE14E1BBF3 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		8A0A85DA27EC46D4005CFC84 /* monaco.iife.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = monaco.iife.js; sourceTree = "<group>"; };
 		8A0A85E727EC5A27005CFC84 /* Advance-zh.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = "Advance-zh.md"; path = "../Advance-zh.md"; sourceTree = "<group>"; };
 		8A0A85E927EC5A8D005CFC84 /* Advance.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = Advance.md; path = ../Advance.md; sourceTree = "<group>"; };
@@ -108,6 +112,8 @@
 		B3D8375C2A3EC5932FB496E1 /* Pods_Fastboard_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Fastboard_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D6E431A78571212D291FEE81 /* Pods_OCExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OCExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DF7341E8918DD7163D4E0518 /* Pods-OCExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCExample.release.xcconfig"; path = "Target Support Files/Pods-OCExample/Pods-OCExample.release.xcconfig"; sourceTree = "<group>"; };
+		F54E2A44D0AF5CC27D05DCEC /* FastProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FastProxy.m; path = ../Fastboard/Classes/Proxy/FastProxy.m; sourceTree = "<group>"; };
+		FC951F612AA06A8376825E3B /* FastProxyTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FastProxyTests.m; path = FastProxyTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -127,17 +133,42 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EBF2C13EC53F15F269995375 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1C5964CB7AE8710737CD748E /* FastboardTest */ = {
+			isa = PBXGroup;
+			children = (
+				FC951F612AA06A8376825E3B /* FastProxyTests.m */,
+			);
+			name = FastboardTest;
+			path = FastboardTest;
+			sourceTree = "<group>";
+		};
 		3486D2D3B0368B45EF0CE9FD /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 				B3D8375C2A3EC5932FB496E1 /* Pods_Fastboard_Tests.framework */,
 				30F099742273D1E816E706CE /* Pods_Fastboard_Example.framework */,
 				D6E431A78571212D291FEE81 /* Pods_OCExample.framework */,
+				3C9FBE1A449AF92046DBDEAF /* iOS */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		3C9FBE1A449AF92046DBDEAF /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				8389C4B657CBD4AE14E1BBF3 /* Foundation.framework */,
+			);
+			name = iOS;
 			sourceTree = "<group>";
 		};
 		607FACC71AFB9204008FA782 = {
@@ -149,6 +180,8 @@
 				607FACD11AFB9204008FA782 /* Products */,
 				CABC05EFD93E2733EB53095A /* Pods */,
 				3486D2D3B0368B45EF0CE9FD /* Frameworks */,
+				1C5964CB7AE8710737CD748E /* FastboardTest */,
+				F54E2A44D0AF5CC27D05DCEC /* FastProxy.m */,
 			);
 			sourceTree = "<group>";
 		};
@@ -157,6 +190,7 @@
 			children = (
 				607FACD01AFB9204008FA782 /* Fastboard_Example.app */,
 				8AAB0ED0277AB0E40062E8D1 /* OCExample.app */,
+				3AEECDDEE22FE3EA5FB0BA80 /* FastboardTest.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -313,6 +347,23 @@
 			productReference = 8AAB0ED0277AB0E40062E8D1 /* OCExample.app */;
 			productType = "com.apple.product-type.application";
 		};
+		DF64B9ACC09332CF0DB3F67B /* FastboardTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4192DC9D0B71097835BA4304 /* Build configuration list for PBXNativeTarget "FastboardTest" */;
+			buildPhases = (
+				ACFBE7FBD7962794EA072486 /* Sources */,
+				EBF2C13EC53F15F269995375 /* Frameworks */,
+				A5E34A9B7B1132CB69B56D62 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FastboardTest;
+			productName = FastboardTest;
+			productReference = 3AEECDDEE22FE3EA5FB0BA80 /* FastboardTest.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -353,6 +404,7 @@
 			targets = (
 				607FACCF1AFB9204008FA782 /* Fastboard_Example */,
 				8AAB0ECF277AB0E40062E8D1 /* OCExample */,
+				DF64B9ACC09332CF0DB3F67B /* FastboardTest */,
 			);
 		};
 /* End PBXProject section */
@@ -386,6 +438,13 @@
 				8AFA91D5278C396D00E0CA61 /* Images.xcassets in Resources */,
 				8A32FA7B27C8AEBF00FA9367 /* storage.json in Resources */,
 				8A28DD1C278BD84E00B5CB71 /* README.md in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A5E34A9B7B1132CB69B56D62 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -525,6 +584,15 @@
 				8A28DD1A278BCBD700B5CB71 /* RoomInfo.m in Sources */,
 				8A32FA7C27C8AEE400FA9367 /* StorageItem.swift in Sources */,
 				8A28DD18278BCB1900B5CB71 /* RoomInfo.h in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ACFBE7FBD7962794EA072486 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2ECE8C6F5A81E613E3C86837 /* FastProxyTests.m in Sources */,
+				9DFFCA4842C8D67D3B523C67 /* FastProxy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -794,9 +862,57 @@
 			};
 			name = Release;
 		};
+		952CE7F23A9FBD13FCFB7E82 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGNING_ALLOWED = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/../Fastboard/Classes/Proxy\"",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.netless.FastboardExample.FastboardTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		EAA82530460CFFA35583027F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGNING_ALLOWED = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/../Fastboard/Classes/Proxy\"",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.netless.FastboardExample.FastboardTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		4192DC9D0B71097835BA4304 /* Build configuration list for PBXNativeTarget "FastboardTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EAA82530460CFFA35583027F /* Release */,
+				952CE7F23A9FBD13FCFB7E82 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		607FACCB1AFB9204008FA782 /* Build configuration list for PBXProject "Fastboard" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Example/FastboardTest/FastProxyTests.m
+++ b/Example/FastboardTest/FastProxyTests.m
@@ -1,0 +1,15 @@
+#import <XCTest/XCTest.h>
+#import "FastProxy.h"
+
+@interface FastProxyTests : XCTestCase
+@end
+
+@implementation FastProxyTests
+
+- (void)testRespondsToSelectorReturnsNOWhenBothTargetsAreNil {
+    FastProxy *proxy = [FastProxy target:nil middleMan:nil];
+    SEL selector = NSSelectorFromString(@"logger:");
+    XCTAssertFalse([proxy respondsToSelector:selector]);
+}
+
+@end

--- a/Fastboard/Classes/Proxy/FastProxy.m
+++ b/Fastboard/Classes/Proxy/FastProxy.m
@@ -19,31 +19,44 @@
     return [[FastProxy alloc] initWithTarget:target middleMan:middleMan];
 }
 
+- (BOOL)respondsToSelector:(SEL)aSelector {
+    id middleMan = self.middleMan;
+    id target = self.target;
+    return [middleMan respondsToSelector:aSelector] || [target respondsToSelector:aSelector];
+}
+
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)sel {
-    id result = [self.target methodSignatureForSelector:sel];
+    id middleMan = self.middleMan;
+    id target = self.target;
+    NSMethodSignature *result = [middleMan methodSignatureForSelector:sel];
     if (!result) {
-        result = [self.middleMan methodSignatureForSelector:sel];
+        result = [target methodSignatureForSelector:sel];
+    }
+    // Prevent NSProxy forwarding crash for respondsToSelector: when both refs are released.
+    if (!result && sel == @selector(respondsToSelector:)) {
+        result = [NSObject instanceMethodSignatureForSelector:@selector(respondsToSelector:)];
     }
     return result;
 }
 
 - (void)forwardInvocation:(NSInvocation *)invocation {
+    id middleMan = self.middleMan;
+    id target = self.target;
+    
     // Should trigger respond to selector only once
     if (invocation.selector == @selector(respondsToSelector:)) {
-        if ([self.middleMan respondsToSelector: invocation.selector]) {
-            [invocation invokeWithTarget:self.middleMan];
-            return;
-        } else if ([self.target respondsToSelector: invocation.selector]) {
-            [invocation invokeWithTarget:self.target];
-            return;
-        }
+        SEL selector = NULL;
+        [invocation getArgument:&selector atIndex:2];
+        BOOL result = [middleMan respondsToSelector:selector] || [target respondsToSelector:selector];
+        [invocation setReturnValue:&result];
+        return;
     }
     
-    if ([self.middleMan respondsToSelector:invocation.selector]) {
-        [invocation invokeWithTarget:self.middleMan];
+    if ([middleMan respondsToSelector:invocation.selector]) {
+        [invocation invokeWithTarget:middleMan];
     }
-    if ([self.target respondsToSelector:invocation.selector]) {
-        [invocation invokeWithTarget:self.target];
+    if ([target respondsToSelector:invocation.selector]) {
+        [invocation invokeWithTarget:target];
     }
 }
 


### PR DESCRIPTION
Summary
- add a regression test for respondsToSelector: when proxy targets are nil and make FastProxy consistently surface selector handling
- ensure methodSignatureForSelector and forwardInvocation guard against nil middle-man/target crashes while keeping respondsToSelector: behavior accurate

Testing
- Not run (not requested)